### PR TITLE
Add option to skip font family validation

### DIFF
--- a/packages/css-processor/src/config.ts
+++ b/packages/css-processor/src/config.ts
@@ -84,6 +84,13 @@ export interface CSSProcessorConfig {
   readonly rootFontSize: number;
 
   /**
+   * Do not normalize font family. It's useful when running on the web where
+   * you can use more than one font family, and it's not as strict as native
+   * platforms.
+   */
+  readonly skipFontFamilyNormalization?: boolean;
+
+  /**
    * Determine is the provided font is supported on running platform.
    *
    * @param fontName - The name of the font to validate. Any quotes have been removed.

--- a/packages/css-processor/src/config.ts
+++ b/packages/css-processor/src/config.ts
@@ -88,7 +88,7 @@ export interface CSSProcessorConfig {
    * you can use more than one font family, and it's not as strict as native
    * platforms.
    */
-  readonly skipFontFamilyNormalization?: boolean;
+  readonly skipFontFamilyValidation?: boolean;
 
   /**
    * Determine is the provided font is supported on running platform.

--- a/packages/css-processor/src/default.ts
+++ b/packages/css-processor/src/default.ts
@@ -37,5 +37,6 @@ export const defaultCSSProcessorConfig: CSSProcessorConfig = {
   inlinePropertiesWhitelist: null,
   isFontSupported() {
     return true;
-  }
+  },
+  skipFontFamilyNormalization: false
 };

--- a/packages/css-processor/src/default.ts
+++ b/packages/css-processor/src/default.ts
@@ -38,5 +38,5 @@ export const defaultCSSProcessorConfig: CSSProcessorConfig = {
   isFontSupported() {
     return true;
   },
-  skipFontFamilyNormalization: false
+  skipFontFamilyValidation: false
 };

--- a/packages/css-processor/src/validators/LongFontFamilyPropertyValidator.ts
+++ b/packages/css-processor/src/validators/LongFontFamilyPropertyValidator.ts
@@ -8,6 +8,10 @@ export class LongFontFamilyPropertyValidator<
   C extends CSSPropertyModel
 > extends LongCSSPropertyValidator<C, string> {
   normalizeRawInlineCSSValue(value: string): string | null {
+    if (this.config.skipFontFamilyNormalization) {
+      return value;
+    }
+
     const values = value.split(SEPARATOR_REGEX);
     for (const font of values) {
       const normalizedFont = normalizeFontName(font);

--- a/packages/css-processor/src/validators/LongFontFamilyPropertyValidator.ts
+++ b/packages/css-processor/src/validators/LongFontFamilyPropertyValidator.ts
@@ -8,7 +8,7 @@ export class LongFontFamilyPropertyValidator<
   C extends CSSPropertyModel
 > extends LongCSSPropertyValidator<C, string> {
   normalizeRawInlineCSSValue(value: string): string | null {
-    if (this.config.skipFontFamilyNormalization) {
+    if (this.config.skipFontFamilyValidation) {
       return value;
     }
 

--- a/packages/css-processor/src/validators/__tests__/LongFontFamilyPropertyValidator.test.ts
+++ b/packages/css-processor/src/validators/__tests__/LongFontFamilyPropertyValidator.test.ts
@@ -38,5 +38,15 @@ describe('FontFamilyPropertyValidator', () => {
         )
       ).toBe('GreatFont');
     });
+    it('should return font as is when config.skipFontFamilyNormalization is true', () => {
+      const registry = registryFromConfig({
+        skipFontFamilyNormalization: true
+      });
+      expect(
+        registry.validators.fontFamily.normalizeInlineCSSValue(
+          'Helvetica, sans-serif'
+        )
+      ).toBe('Helvetica, sans-serif');
+    });
   });
 });

--- a/packages/css-processor/src/validators/__tests__/LongFontFamilyPropertyValidator.test.ts
+++ b/packages/css-processor/src/validators/__tests__/LongFontFamilyPropertyValidator.test.ts
@@ -38,9 +38,9 @@ describe('FontFamilyPropertyValidator', () => {
         )
       ).toBe('GreatFont');
     });
-    it('should return font as is when config.skipFontFamilyNormalization is true', () => {
+    it('should return font as is when config.skipFontFamilyValidation is true', () => {
       const registry = registryFromConfig({
-        skipFontFamilyNormalization: true
+        skipFontFamilyValidation: true
       });
       expect(
         registry.validators.fontFamily.normalizeInlineCSSValue(


### PR DESCRIPTION
The reason behind this PR is the following issue we're dealing with here: https://github.com/Expensify/App/issues/31389. We're using https://github.com/meliorence/react-native-render-html, which in turn uses this library for CSS processing.

The `css-processor` package will validate all fonts passed via CSS in order to filter out the first valid one found. This is required because react native on native platforms only support a single `font-family` and will break if you pass more than one. The problem here is that RN can also run on the Web, via React Native Web, and this restriction does not exist on the web.

The idea here is to expose a new configuration option that would bypass the font-family validation (`LongFontFamilyPropertyValidatior`) so that it would use the input value as is. With this new configuration, `react-native-render-html` could either pass `skipFontFamilyValidation = Platform.OS === 'web'` or it could expose this configuration option to the final user of `react-native-render-html` which would then be able to decide whether to disable or not this validation. We'd work on a PR for `react-native-render-html` if this gets any traction.