### PR TITLE
🔥remove  `@types/react-native` peer dependency requirement

### DIFF
--- a/packages/css-processor/package.json
+++ b/packages/css-processor/package.json
@@ -57,8 +57,7 @@
     "typescript": "~4.2.4"
   },
   "peerDependencies": {
-    "@types/react": "*",
-    "@types/react-native": "*"
+    "@types/react": "*"
   },
   "dependencies": {
     "css-to-react-native": "^3.0.0",

--- a/packages/transient-render-engine/package.json
+++ b/packages/transient-render-engine/package.json
@@ -57,7 +57,6 @@
     "typescript": "~4.2.4"
   },
   "peerDependencies": {
-    "@types/react-native": "*",
     "react-native": "^*"
   },
   "publishConfig": {


### PR DESCRIPTION
React Native now natively supports Typescript so the [`@types/react-native`](https://www.npmjs.com/package/@types/react-native) package has been deprecated.  While using it for this project is fine since it was written to work with an earlier version of React Native, it should not be a peer dependency for other projects.