### PR TITLE
fix: ARenderer TypeError when href is undefined

### DIFF
--- a/packages/render/src/__tests__/regression.32.anchor-href-undefined-with-base-url.test.tsx
+++ b/packages/render/src/__tests__/regression.32.anchor-href-undefined-with-base-url.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import RenderHTML from '../RenderHTML';
+
+/**
+ * https://github.com/native-html/render/pull/32
+ */
+describe('RenderHTML component', () => {
+  describe('should pass regression #32 regarding anchor without href when baseUrl is provided', () => {
+    it('should mount without throwing', () => {
+      const { getByText } = render(
+        <RenderHTML
+          debug={false}
+          source={{
+            html: '<a>link label</a>',
+            baseUrl: 'https://example.com/'
+          }}
+        />
+      );
+      expect(getByText('link label')).toBeTruthy();
+    });
+  });
+});

--- a/packages/render/src/renderers/ARenderer.tsx
+++ b/packages/render/src/renderers/ARenderer.tsx
@@ -16,8 +16,9 @@ function useAnchorOnLinkPress(
   const { baseTarget } = useDocumentMetadata();
   const shouldHandleLinkPress =
     tnode.tagName === 'a' &&
-    typeof normalizedHref === 'string' &&
+    typeof href === 'string' &&
     href.length > 0 &&
+    typeof normalizedHref === 'string' &&
     typeof onPress === 'function';
   return shouldHandleLinkPress
     ? (e: GestureResponderEvent) =>


### PR DESCRIPTION
Fixes TypeError on `href.length` when href is undefined
- tests `typeof href` is string before reading its length

`useNormalizedUrl` can return `undefined` if it fails to parse absolute an url (see: [normalizeResourceLocator.ts](https://github.com/native-html/render/blob/main/packages/render/src/helpers/normalizeResourceLocator.ts#L8))

> `[TypeError: Cannot read property 'length' of undefined]`