### PR TITLE
fix(transient-render-engine): preserve nested inline boundary spaces

### DIFF
--- a/packages/transient-render-engine/src/flow/__tests__/__snapshots__/collapse.test.ts.snap
+++ b/packages/transient-render-engine/src/flow/__tests__/__snapshots__/collapse.test.ts.snap
@@ -140,6 +140,18 @@ exports[`collapse function should not collapse when white-space CSS property is 
 </TBlock>
 `;
 
+exports[`collapse function should preserve boundary spaces wrapped in nested inline phrasing tags 1`] = `
+<TPhrasing tagName="span" nodeIndex={0}>
+  <TPhrasing tagName="span" nodeIndex={0}>
+    <TText tagName="strong" nodeIndex={0} data="foo" />
+    <TText anonymous nodeIndex={1} data=" " />
+  </TPhrasing>
+  <TPhrasing tagName="span" nodeIndex={1}>
+    <TText tagName="strong" nodeIndex={0} data="bar" />
+  </TPhrasing>
+</TPhrasing>
+`;
+
 exports[`collapse function should remove children from TPhrasing nodes which are empty after timming 1`] = `
 <TPhrasing anonymous nodeIndex={0}>
   <TText anonymous nodeIndex={0} data="Foo" />

--- a/packages/transient-render-engine/src/flow/__tests__/collapse.test.ts
+++ b/packages/transient-render-engine/src/flow/__tests__/collapse.test.ts
@@ -37,6 +37,19 @@ describe('collapse function', () => {
     const ttree = makeTTree('<span><span>foo </span><span> bar</span></span>');
     expect(ttree).toMatchSnapshot();
   });
+  it('should preserve boundary spaces wrapped in nested inline phrasing tags', () => {
+    const ttree = makeTTree(
+      '<span><span><strong>foo</strong> </span><span><strong>bar</strong></span></span>'
+    );
+    const [firstSpan, secondSpan] = ttree.children;
+    expect(firstSpan.tagName).toBe('span');
+    expect(firstSpan.children).toHaveLength(2);
+    expect((firstSpan.children[0] as TTextImpl).data).toBe('foo');
+    expect((firstSpan.children[1] as TTextImpl).data).toBe(' ');
+    expect(secondSpan.tagName).toBe('span');
+    expect(secondSpan.children).toHaveLength(1);
+    expect((secondSpan.children[0] as TTextImpl).data).toBe('bar');
+  });
   it('should handle nested anchors', () => {
     const ttree = makeTTree(nestedHyperlinksSource);
     expect(ttree).toMatchSnapshot();

--- a/packages/transient-render-engine/src/flow/__tests__/collapse.test.ts
+++ b/packages/transient-render-engine/src/flow/__tests__/collapse.test.ts
@@ -41,14 +41,16 @@ describe('collapse function', () => {
     const ttree = makeTTree(
       '<span><span><strong>foo</strong> </span><span><strong>bar</strong></span></span>'
     );
-    const [firstSpan, secondSpan] = ttree.children;
-    expect(firstSpan.tagName).toBe('span');
-    expect(firstSpan.children).toHaveLength(2);
-    expect((firstSpan.children[0] as TTextImpl).data).toBe('foo');
-    expect((firstSpan.children[1] as TTextImpl).data).toBe(' ');
-    expect(secondSpan.tagName).toBe('span');
-    expect(secondSpan.children).toHaveLength(1);
-    expect((secondSpan.children[0] as TTextImpl).data).toBe('bar');
+    expect(ttree).toMatchSnapshot();
+  });
+  it('should collapse consecutive boundary spaces wrapped in nested inline phrasing tags', () => {
+    const twoSpaces = makeTTree(
+      '<span><span><strong>foo</strong>  </span><span><strong>bar</strong></span></span>'
+    );
+    const oneSpace = makeTTree(
+      '<span><span><strong>foo</strong> </span><span><strong>bar</strong></span></span>'
+    );
+    expect(twoSpaces).toEqual(oneSpace);
   });
   it('should handle nested anchors', () => {
     const ttree = makeTTree(nestedHyperlinksSource);

--- a/packages/transient-render-engine/src/tree/TPhrasingCtor.ts
+++ b/packages/transient-render-engine/src/tree/TPhrasingCtor.ts
@@ -48,8 +48,12 @@ TPhrasingCtor.prototype.collapseChildren = function collapseChildren() {
     }
     previous = childK;
   });
-  this.trimLeft();
-  this.trimRight();
+  // Preserve boundary spaces for named inline wrappers (e.g. styled spans) so
+  // their parent phrasing container can collapse sibling boundaries correctly.
+  if (this.tagName === null) {
+    this.trimLeft();
+    this.trimRight();
+  }
   return null;
 };
 


### PR DESCRIPTION
## Summary
Fix whitespace collapsing for nested inline phrasing nodes so boundary spaces inside named inline wrappers like span are preserved until the parent phrasing node collapses sibling whitespace correctly.

Adds a regression test for nested inline tags that previously rendered foo bar as foobar.

Closes [#33](https://github.com/native-html/render/issues/33)