### PR TITLE
fix: changelog link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You like to learn by example? We have a tutorial from which the demo GIF has bee
 
 ## :notebook: Changelog
 
-The changelog is available here: [packages/render-html/CHANGELOG.md](./packages/render-html/CHANGELOG.md).
+The changelog is available here: [packages/render/CHANGELOG.md](./packages/render/CHANGELOG.md).
 
 ## :bulb: Help
 


### PR DESCRIPTION
Documentation only. The `README.md` incorrectly linked to `render-html` package instead of `render` package.  This just updates the link.