### PR TITLE
feat: add TText renderer to override all text nodes, including anonymous text

### DIFF
--- a/packages/render/src/render/RenderRegistry.ts
+++ b/packages/render/src/render/RenderRegistry.ts
@@ -45,8 +45,18 @@ export default class RenderRegistry {
   }
 
   getRendererConfigForTNode<T extends TNode>(tnode: T): RendererConfig<T> {
+    let custom = this.getCustomRendererForTNode(tnode);
+    
+    // Allow overriding all text nodes via TText
+    if (!custom && tnode.type === 'text') {
+      const textRenderer = this.customRenderers['TText'];
+      if (textRenderer) {
+        custom = textRenderer as any;
+      }
+    }
+    
     return {
-      Custom: this.getCustomRendererForTNode(tnode),
+      Custom: custom,
       Default: this.getDefaultRendererForTNode(tnode)
     };
   }


### PR DESCRIPTION
## Summary

This PR adds support for a new special key `TText` in the `renderers` prop to override the rendering of **all text nodes**, including **anonymous text** (text without an enclosing HTML tag).

## The Problem

Currently, custom renderers are resolved only by `tagName`. Anonymous text has `tagName === null`, so it cannot be intercepted. Developers must override every possible tag (`p`, `span`, `div`, …) and still miss anonymous text.

### Example

```html
<div>
  This is anonymous text   <!-- ❌ Cannot be overridden -->
  <span>Tagged text</span> <!-- ✅ Can be overridden via "span" key -->
</div>
```

## The Fix

Modify `RenderRegistry.getRendererConfigForTNode` to check for `TText` when `tnode.type === 'text'` and no custom renderer was found by `tagName`.

## Implementation

```ts
getRendererConfigForTNode<T extends TNode>(tnode: T): RendererConfig<T> {
  let custom = this.getCustomRendererForTNode(tnode);

  if (!custom && tnode.type === 'text') {
    const textRenderer = this.customRenderers['TText'];
    if (textRenderer) {
      custom = textRenderer as any;
    }
  }

  return {
    Custom: custom,
    Default: this.getDefaultRendererForTNode(tnode)
  };
}
```